### PR TITLE
Change deployment.replicas_ready to deployment.replicas_available as replicas_ready doesn't exist

### DIFF
--- a/catalog/monitors/k8s.yaml
+++ b/catalog/monitors/k8s.yaml
@@ -5,7 +5,7 @@ k8s-deployment-replica-pod-down:
   name: "(k8s) Deployment Replica Pod is down"
   type: query alert
   query: |
-    avg(last_15m):avg:kubernetes_state.deployment.replicas_desired{*} by {cluster_name,deployment} - avg:kubernetes_state.deployment.replicas_ready{*} by {cluster_name,deployment} >= 2
+    avg(last_15m):avg:kubernetes_state.deployment.replicas_desired{*} by {cluster_name,deployment} - avg:kubernetes_state.deployment.replicas_available{*} by {cluster_name,deployment} >= 2
   message: |
     ({{cluster_name.name}}) More than one Deployments Replica's pods are down on {{deployment.name}}
   escalation_message: ""


### PR DESCRIPTION


## what
By looking at the datadog kube metrics documentation, it doesn't look like `kubernetes_state.deployment.replicas_ready` is a metric that is shipped. https://docs.datadoghq.com/agent/kubernetes/data_collected/#kubernetes-state

As I am new to datadog, I am unsure whether this metric used to exist and was possibly deprecated.

I also cannot find the `kubernetes_state.deployment.replicas_ready` metric in my DataDog environment:
<img width="1001" alt="Screen Shot 2021-02-23 at 12 25 03 PM" src="https://user-images.githubusercontent.com/27699163/108903933-bb3f4580-75d2-11eb-9ad8-e67993317ad7.png">

## why
The `(k8s) Deployment Replica Pod is down` monitor is incorrectly reporting my deployment replica pods are down for deployments with >= 2 pods.

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`

