### PR TITLE
Feature: add child organization module

### DIFF
--- a/modules/child_organization/child_organization.auto.tfvars
+++ b/modules/child_organization/child_organization.auto.tfvars
@@ -1,0 +1,1 @@
+id_length_limit = 32

--- a/modules/child_organization/context.tf
+++ b/modules/child_organization/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/child_organization/datadog-child-organization.md
+++ b/modules/child_organization/datadog-child-organization.md
@@ -1,0 +1,1 @@
+# Datadog Child Organization

--- a/modules/child_organization/main.tf
+++ b/modules/child_organization/main.tf
@@ -1,0 +1,35 @@
+# https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/child_organization
+# https://github.com/hashicorp/cdktf-provider-datadog/blob/main/API.md
+
+# Create a new Datadog Child Organization
+resource "datadog_child_organization" "default" {
+  name = var.name
+}
+
+resource "datadog_organization_settings" {
+
+  saml = [{
+    enabled = var.saml_enabled
+  }]
+
+  saml_autocreate_users_domains = [{
+    domains = var.saml_autocreate_users_domains
+    enabled = len(var.saml_autocreate_users_domains) > 0 ? true : false
+  }]
+
+  saml_idp_initiated_login = [{
+    enabled = var.saml_idp_initiated_login_enabled
+  }]
+
+  saml_strict_mode = [{
+    enabled = var.saml_strict_mode_enabled
+  }]
+
+  private_widget_share = var.private_widget_share
+
+  saml_autocreate_access_role = var.saml_autocreate_access_role
+}
+
+locals {
+  enabled     = module.this.enabled
+}

--- a/modules/child_organization/main.tf
+++ b/modules/child_organization/main.tf
@@ -4,11 +4,11 @@
 # Create a new Datadog Child Organization
 
 resource "datadog_child_organization" "default" {
-  name                          = var.organization_name
+  name = var.organization_name
 }
 
 resource "datadog_organization_settings" "default" {
-  name                          = var.organization_name
+  name = var.organization_name
   settings {
     saml {
       enabled = var.saml_enabled

--- a/modules/child_organization/main.tf
+++ b/modules/child_organization/main.tf
@@ -31,5 +31,5 @@ resource "datadog_organization_settings" {
 }
 
 locals {
-  enabled     = module.this.enabled
+  enabled = module.this.enabled
 }

--- a/modules/child_organization/main.tf
+++ b/modules/child_organization/main.tf
@@ -2,12 +2,13 @@
 # https://github.com/hashicorp/cdktf-provider-datadog/blob/main/API.md
 
 # Create a new Datadog Child Organization
+
 resource "datadog_child_organization" "default" {
-  name                          = module.this.id
+  name                          = var.organization_name
 }
 
 resource "datadog_organization_settings" "default" {
-  name                          = module.this.id
+  name                          = var.organization_name
   settings {
     saml {
       enabled = var.saml_enabled
@@ -20,6 +21,10 @@ resource "datadog_organization_settings" "default" {
 
     saml_strict_mode {
       enabled = var.saml_strict_mode_enabled
+    }
+
+    saml_idp_initiated_login {
+      enabled = var.saml_idp_initiated_login_enabled
     }
 
     private_widget_share = var.private_widget_share

--- a/modules/child_organization/main.tf
+++ b/modules/child_organization/main.tf
@@ -3,31 +3,33 @@
 
 # Create a new Datadog Child Organization
 resource "datadog_child_organization" "default" {
-  name = var.name
+  name                          = module.this.id
 }
 
-resource "datadog_organization_settings" {
+resource "datadog_organization_settings" "default" {
+  name                          = module.this.id
+  settings {
+    saml {
+      enabled = var.saml_enabled
+    }
 
-  saml = [{
-    enabled = var.saml_enabled
-  }]
+    saml_autocreate_users_domains {
+      domains = var.saml_autocreate_users_domains
+      enabled = length(var.saml_autocreate_users_domains) > 0
+    }
 
-  saml_autocreate_users_domains = [{
-    domains = var.saml_autocreate_users_domains
-    enabled = len(var.saml_autocreate_users_domains) > 0 ? true : false
-  }]
+    saml_idp_initiated_login {
+      enabled = var.saml_idp_initiated_login_enabled
+    }
 
-  saml_idp_initiated_login = [{
-    enabled = var.saml_idp_initiated_login_enabled
-  }]
+    saml_strict_mode {
+      enabled = var.saml_strict_mode_enabled
+    }
 
-  saml_strict_mode = [{
-    enabled = var.saml_strict_mode_enabled
-  }]
+    private_widget_share = var.private_widget_share
 
-  private_widget_share = var.private_widget_share
-
-  saml_autocreate_access_role = var.saml_autocreate_access_role
+    saml_autocreate_access_role = var.saml_autocreate_access_role
+  }
 }
 
 locals {

--- a/modules/child_organization/outputs.tf
+++ b/modules/child_organization/outputs.tf
@@ -1,0 +1,8 @@
+output "saml_idp_endpoint" {
+    value = resource.datadog_organization_settings.saml_idp_endpoint
+    description = "The SAML IDP endpoint for the organization"
+}
+
+output "saml_login_url" {
+    value = resource.datadog_organization_settings.saml_login_url
+}

--- a/modules/child_organization/outputs.tf
+++ b/modules/child_organization/outputs.tf
@@ -1,8 +1,16 @@
-# output "saml_idp_endpoint" {
-#   value       = datadog_organization_settings.saml_idp_endpoint
-#   description = "The SAML IDP endpoint for the organization"
-# }
+output "api_key" {
+  value = datadog_child_organization.default.api_key
+  description = "The API key for the root organization user"
+}
+output "application_key" {
+  value = datadog_child_organization.default.application_key
+  description = "The application key for the root organization user"
+}
+output "saml_idp_endpoint" {
+  value       = datadog_organization_settings.default.settings[0].saml_idp_endpoint
+  description = "The SAML IDP endpoint for the organization"
+}
 
-# output "saml_login_url" {
-#   value = datadog_organization_settings.saml_login_url
-# }
+output "saml_login_url" {
+  value = datadog_organization_settings.default.settings[0].saml_login_url
+}

--- a/modules/child_organization/outputs.tf
+++ b/modules/child_organization/outputs.tf
@@ -1,9 +1,9 @@
 output "api_key" {
-  value = datadog_child_organization.default.api_key
+  value       = datadog_child_organization.default.api_key
   description = "The API key for the root organization user"
 }
 output "application_key" {
-  value = datadog_child_organization.default.application_key
+  value       = datadog_child_organization.default.application_key
   description = "The application key for the root organization user"
 }
 output "saml_idp_endpoint" {

--- a/modules/child_organization/outputs.tf
+++ b/modules/child_organization/outputs.tf
@@ -1,8 +1,8 @@
-output "saml_idp_endpoint" {
-  value       = resource.datadog_organization_settings.saml_idp_endpoint
-  description = "The SAML IDP endpoint for the organization"
-}
+# output "saml_idp_endpoint" {
+#   value       = datadog_organization_settings.saml_idp_endpoint
+#   description = "The SAML IDP endpoint for the organization"
+# }
 
-output "saml_login_url" {
-  value = resource.datadog_organization_settings.saml_login_url
-}
+# output "saml_login_url" {
+#   value = datadog_organization_settings.saml_login_url
+# }

--- a/modules/child_organization/outputs.tf
+++ b/modules/child_organization/outputs.tf
@@ -1,8 +1,8 @@
 output "saml_idp_endpoint" {
-    value = resource.datadog_organization_settings.saml_idp_endpoint
-    description = "The SAML IDP endpoint for the organization"
+  value       = resource.datadog_organization_settings.saml_idp_endpoint
+  description = "The SAML IDP endpoint for the organization"
 }
 
 output "saml_login_url" {
-    value = resource.datadog_organization_settings.saml_login_url
+  value = resource.datadog_organization_settings.saml_login_url
 }

--- a/modules/child_organization/variables.tf
+++ b/modules/child_organization/variables.tf
@@ -1,0 +1,36 @@
+# https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication
+variable "saml_enabled" {
+  type = bool
+  default = true
+  description = "Whether SAML is enabled for the child organization"
+}
+
+variable "saml_autocreate_users_domains" {
+  type = list(string)
+  default = []
+  description = "List of domains where the SAML automated user creation is enabled."
+}
+
+variable "saml_idp_initiated_login_enabled" {
+  type = bool
+  default = true
+  description = "Whether SAML is enabled for the child organization"
+}
+
+variable "saml_strict_mode_enabled" {
+  type = bool
+  default = true
+  description = "Whether to enforce SAML login only for all users"
+}
+
+variable "private_widget_share" {
+  type = bool
+  default = false
+  description = "Whether or not organization users can share widgets outside of datadog"
+}
+
+variable "saml_autocreate_access_role" {
+  type = string
+  default = "ro"
+  description = "The access role of an autocreated user. Options are `st` (standard user), `adm` (admin user), or `ro` (read-only user). Allowed enum values: `st`, `adm` , `ro`, `ERROR`"
+}

--- a/modules/child_organization/variables.tf
+++ b/modules/child_organization/variables.tf
@@ -1,36 +1,36 @@
 # https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication
 variable "saml_enabled" {
-  type = bool
-  default = true
+  type        = bool
+  default     = true
   description = "Whether SAML is enabled for the child organization"
 }
 
 variable "saml_autocreate_users_domains" {
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
   description = "List of domains where the SAML automated user creation is enabled."
 }
 
 variable "saml_idp_initiated_login_enabled" {
-  type = bool
-  default = true
+  type        = bool
+  default     = true
   description = "Whether SAML is enabled for the child organization"
 }
 
 variable "saml_strict_mode_enabled" {
-  type = bool
-  default = true
+  type        = bool
+  default     = true
   description = "Whether to enforce SAML login only for all users"
 }
 
 variable "private_widget_share" {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Whether or not organization users can share widgets outside of datadog"
 }
 
 variable "saml_autocreate_access_role" {
-  type = string
-  default = "ro"
+  type        = string
+  default     = "ro"
   description = "The access role of an autocreated user. Options are `st` (standard user), `adm` (admin user), or `ro` (read-only user). Allowed enum values: `st`, `adm` , `ro`, `ERROR`"
 }

--- a/modules/child_organization/variables.tf
+++ b/modules/child_organization/variables.tf
@@ -1,4 +1,4 @@
-# https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication
+# https://docs.datadoghq.com/account_management/org_settings/#overview
 variable "saml_enabled" {
   type        = bool
   default     = true

--- a/modules/child_organization/variables.tf
+++ b/modules/child_organization/variables.tf
@@ -1,7 +1,7 @@
 # https://docs.datadoghq.com/account_management/org_settings/#overview
 
 variable "name" {
-  type = string
+  type        = string
   description = "The name of the datadog child organization"
 }
 variable "saml_enabled" {

--- a/modules/child_organization/variables.tf
+++ b/modules/child_organization/variables.tf
@@ -1,4 +1,9 @@
 # https://docs.datadoghq.com/account_management/org_settings/#overview
+
+variable "organization_name" {
+  type = string
+  description = "The name of the datadog child organization"
+}
 variable "saml_enabled" {
   type        = bool
   default     = true

--- a/modules/child_organization/versions.tf
+++ b/modules/child_organization/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 0.13.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.3"
+    }
+    datadog = {
+      source  = "datadog/datadog"
+      version = ">= 3.0.0"
+    }
+  }
+}


### PR DESCRIPTION
WIP but wanted to have @aknysh take a look before doing things like adding to the readme and testing

## what
* Add child organization resource to terraform-datadog-platform

## why
* I have a need for this resource and think cloudposse would be interested in maintaining this module as part of their datadog platform (e.g. business case). 

## references
* https://github.com/DataDog/terraform-provider-datadog/issues/878
* previous pr https://github.com/cloudposse/terraform-datadog-platform/pull/44

