### PR TITLE
Do not provision dd org settings and default saml_enabled to false

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -118,124 +118,124 @@ usage: |-
   Provision Datadog monitors from the catalog of YAML definitions:
 
   ```hcl
-    module "monitor_configs" {
-      source  = "cloudposse/config/yaml"
-      version = "0.8.1"
+  module "monitor_configs" {
+    source  = "cloudposse/config/yaml"
+    version = "0.8.1"
 
-      map_config_local_base_path = path.module
-      map_config_paths           = var.monitor_paths
+    map_config_local_base_path = path.module
+    map_config_paths           = var.monitor_paths
 
-      context = module.this.context
-    }
+    context = module.this.context
+  }
 
-    module "datadog_monitors" {
-      source = "cloudposse/platform/datadog//modules/monitors"
-      # version = "x.x.x"
+  module "datadog_monitors" {
+    source = "cloudposse/platform/datadog//modules/monitors"
+    # version = "x.x.x"
 
-      datadog_monitors     = module.monitor_configs.map_configs
-      alert_tags           = var.alert_tags
-      alert_tags_separator = var.alert_tags_separator
+    datadog_monitors     = module.monitor_configs.map_configs
+    alert_tags           = var.alert_tags
+    alert_tags_separator = var.alert_tags_separator
 
-      context = module.this.context
-   }
+    context = module.this.context
+  }
   ```
 
   Provision Datadog synthetics:
 
   ```hcl
-    locals {
-      synthetics_files = flatten([for p in var.synthetic_paths : fileset(path.module, p)])
-      synthetics_list  = [for f in local.synthetics_files : yamldecode(file(f))]
-      synthetics_map   = merge(local.synthetics_list...)
-    }
+  locals {
+    synthetics_files = flatten([for p in var.synthetic_paths : fileset(path.module, p)])
+    synthetics_list  = [for f in local.synthetics_files : yamldecode(file(f))]
+    synthetics_map   = merge(local.synthetics_list...)
+  }
 
-    module "datadog_synthetics" {
-      source = "cloudposse/platform/datadog//modules/synthetics"
-      # version = "x.x.x"
+  module "datadog_synthetics" {
+    source = "cloudposse/platform/datadog//modules/synthetics"
+    # version = "x.x.x"
 
-      datadog_synthetics   = local.synthetics_map
-      alert_tags           = var.alert_tags
-      alert_tags_separator = var.alert_tags_separator
+    datadog_synthetics   = local.synthetics_map
+    alert_tags           = var.alert_tags
+    alert_tags_separator = var.alert_tags_separator
 
-      context = module.this.context
-    }
+    context = module.this.context
+  }
   ```
 
   Provision Datadog monitors, Datadog roles with defined permissions, and assign roles to monitors:
 
   ```hcl
-    module "monitor_configs" {
-      source  = "cloudposse/config/yaml"
-      version = "0.8.1"
+  module "monitor_configs" {
+    source  = "cloudposse/config/yaml"
+    version = "0.8.1"
 
-      map_config_local_base_path = path.module
-      map_config_paths           = var.monitor_paths
+    map_config_local_base_path = path.module
+    map_config_paths           = var.monitor_paths
 
-      context = module.this.context
+    context = module.this.context
+  }
+
+  module "role_configs" {
+    source  = "cloudposse/config/yaml"
+    version = "0.8.1"
+
+    map_config_local_base_path = path.module
+    map_config_paths           = var.role_paths
+
+    context = module.this.context
+  }
+
+  locals {
+    monitors_write_role_name    = module.datadog_roles.datadog_roles["monitors-write"].name
+    monitors_downtime_role_name = module.datadog_roles.datadog_roles["monitors-downtime"].name
+
+    monitors_roles_map = {
+      aurora-replica-lag              = [local.monitors_write_role_name, local.monitors_downtime_role_name]
+      ec2-failed-status-check         = [local.monitors_write_role_name, local.monitors_downtime_role_name]
+      redshift-health-status          = [local.monitors_downtime_role_name]
+      k8s-deployment-replica-pod-down = [local.monitors_write_role_name]
     }
+  }
 
-    module "role_configs" {
-      source  = "cloudposse/config/yaml"
-      version = "0.8.1"
+  module "datadog_roles" {
+    source = "cloudposse/platform/datadog//modules/roles"
+    # version = "x.x.x"
 
-      map_config_local_base_path = path.module
-      map_config_paths           = var.role_paths
+    datadog_roles = module.role_configs.map_configs
 
-      context = module.this.context
-    }
+    context = module.this.context
+  }
 
-    locals {
-      monitors_write_role_name    = module.datadog_roles.datadog_roles["monitors-write"].name
-      monitors_downtime_role_name = module.datadog_roles.datadog_roles["monitors-downtime"].name
+  module "datadog_monitors" {
+    source = "cloudposse/platform/datadog//modules/monitors"
+    # version = "x.x.x"
 
-      monitors_roles_map = {
-        aurora-replica-lag              = [local.monitors_write_role_name, local.monitors_downtime_role_name]
-        ec2-failed-status-check         = [local.monitors_write_role_name, local.monitors_downtime_role_name]
-        redshift-health-status          = [local.monitors_downtime_role_name]
-        k8s-deployment-replica-pod-down = [local.monitors_write_role_name]
-      }
-    }
+    datadog_monitors     = module.monitor_configs.map_configs
+    alert_tags           = var.alert_tags
+    alert_tags_separator = var.alert_tags_separator
+    restricted_roles_map = local.monitors_roles_map
 
-    module "datadog_roles" {
-      source = "cloudposse/platform/datadog//modules/roles"
-      # version = "x.x.x"
-
-      datadog_roles = module.role_configs.map_configs
-
-      context = module.this.context
-    }
-
-    module "datadog_monitors" {
-      source = "cloudposse/platform/datadog//modules/monitors"
-      # version = "x.x.x"
-
-      datadog_monitors     = module.monitor_configs.map_configs
-      alert_tags           = var.alert_tags
-      alert_tags_separator = var.alert_tags_separator
-      restricted_roles_map = local.monitors_roles_map
-
-      context = module.this.context
-    }
+    context = module.this.context
+  }
   ```
 
   Provision a Datadog child organization:
 
   ```hcl
-    module "datadog_child_organization" {
-      source = "cloudposse/platform/datadog//modules/child_organization"
-      # version = "x.x.x"
+  module "datadog_child_organization" {
+    source = "cloudposse/platform/datadog//modules/child_organization"
+    # version = "x.x.x"
 
-      organization_name                = "test"
-      saml_enabled                     = false  # Note that Free and Trial organizations cannot enable SAML
-      saml_autocreate_users_domains    = []
-      saml_autocreate_users_enabled    = false
-      saml_idp_initiated_login_enabled = true
-      saml_strict_mode_enabled         = false
-      private_widget_share             = false
-      saml_autocreate_access_role      = "ro"
+    organization_name                = "test"
+    saml_enabled                     = false  # Note that Free and Trial organizations cannot enable SAML
+    saml_autocreate_users_domains    = []
+    saml_autocreate_users_enabled    = false
+    saml_idp_initiated_login_enabled = true
+    saml_strict_mode_enabled         = false
+    private_widget_share             = false
+    saml_autocreate_access_role      = "ro"
 
-      context = module.this.context
-    }
+    context = module.this.context
+  }
   ```
 
 examples: |-
@@ -255,3 +255,5 @@ contributors:
     github: "SweetOps"
   - name: "Yonatan Koren"
     github: "korenyoni"
+  - name: "RB"
+    github: "nitrocode"

--- a/modules/child_organization/main.tf
+++ b/modules/child_organization/main.tf
@@ -11,24 +11,14 @@ resource "datadog_child_organization" "default" {
   name  = var.organization_name
 }
 
-# Sets a new provider
-provider "datadog" {
-  alias = "organization"
-
-  validate = local.enabled
-
-  datadog_api_key = local.enabled ? join("", datadog_child_organization.default.*.api_key) : null
-  datadog_app_key = local.enabled ? join("", datadog_child_organization.default.*.application_key) : null
-}
-
-# Set organization settings for the new org
 # If provider is not set, it will try to modify the root org settings
+# New provider cannot be set until org is created
+# This resource needs to be moved out of this component and provisioned separately
+# due to provider not allowed in a for_each.
 resource "datadog_organization_settings" "default" {
-  count = local.enabled ? 1 : 0
+  count = 0
 
   name = var.organization_name
-
-  providers = datadog.organization
 
   settings {
     saml {

--- a/modules/child_organization/main.tf
+++ b/modules/child_organization/main.tf
@@ -14,9 +14,9 @@ resource "datadog_child_organization" "default" {
 # Sets a new provider
 provider "datadog" {
   alias = "organization"
-  
+
   validate = local.enabled
-  
+
   datadog_api_key = local.enabled ? join("", datadog_child_organization.default.*.api_key) : null
   datadog_app_key = local.enabled ? join("", datadog_child_organization.default.*.application_key) : null
 }
@@ -27,7 +27,7 @@ resource "datadog_organization_settings" "default" {
   count = local.enabled ? 1 : 0
 
   name = var.organization_name
-  
+
   providers = datadog.organization
 
   settings {

--- a/modules/child_organization/variables.tf
+++ b/modules/child_organization/variables.tf
@@ -7,7 +7,7 @@ variable "organization_name" {
 
 variable "saml_enabled" {
   type        = bool
-  default     = true
+  default     = false
   description = "Whether or not SAML is enabled for the child organization. Note that Free and Trial organizations cannot enable SAML"
 }
 


### PR DESCRIPTION
## what
* Do not provision dd org settings
* default saml_enabled to false

## why
* Prevent dd org settings from updating root org instead of updating child org
* Prevent datadog org creation from failing

## references
N/A

