### PR TITLE
Additional monitor inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,9 +279,8 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.0.0 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
 
 ## Providers
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,9 +4,8 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.0.0 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
 
 ## Providers
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,11 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.3"
+      version = ">= 3.0"
     }
     datadog = {
       source  = "datadog/datadog"

--- a/examples/rbac/versions.tf
+++ b/examples/rbac/versions.tf
@@ -4,11 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.3"
+      version = ">= 3.0"
     }
     datadog = {
       source  = "datadog/datadog"

--- a/examples/slo/versions.tf
+++ b/examples/slo/versions.tf
@@ -4,11 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.3"
+      version = ">= 3.0"
     }
     datadog = {
       source  = "datadog/datadog"

--- a/examples/synthetics/versions.tf
+++ b/examples/synthetics/versions.tf
@@ -4,11 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.3"
+      version = ">= 3.0"
     }
     datadog = {
       source  = "datadog/datadog"

--- a/modules/child_organization/versions.tf
+++ b/modules/child_organization/versions.tf
@@ -4,11 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.3"
+      version = ">= 3.0"
     }
     datadog = {
       source  = "datadog/datadog"

--- a/modules/monitors/main.tf
+++ b/modules/monitors/main.tf
@@ -7,23 +7,30 @@ locals {
 resource "datadog_monitor" "default" {
   for_each = local.enabled ? var.datadog_monitors : {}
 
-  name                = each.value.name
-  type                = each.value.type
-  query               = each.value.query
-  message             = format("%s%s", each.value.message, local.alert_tags)
-  escalation_message  = lookup(each.value, "escalation_message", null)
-  require_full_window = lookup(each.value, "require_full_window", null)
-  notify_no_data      = lookup(each.value, "notify_no_data", null)
-  new_host_delay      = lookup(each.value, "new_host_delay", null)
-  evaluation_delay    = lookup(each.value, "evaluation_delay", null)
-  no_data_timeframe   = lookup(each.value, "no_data_timeframe", null)
-  renotify_interval   = lookup(each.value, "renotify_interval", null)
-  notify_audit        = lookup(each.value, "notify_audit", null)
-  timeout_h           = lookup(each.value, "timeout_h", null)
-  include_tags        = lookup(each.value, "include_tags", null)
-  enable_logs_sample  = lookup(each.value, "enable_logs_sample", null)
-  force_delete        = lookup(each.value, "force_delete", null)
-  priority            = lookup(each.value, "priority", null)
+  name                   = each.value.name
+  type                   = each.value.type
+  query                  = each.value.query
+  message                = format("%s%s", each.value.message, local.alert_tags)
+  escalation_message     = lookup(each.value, "escalation_message", null)
+  require_full_window    = lookup(each.value, "require_full_window", null)
+  notify_no_data         = lookup(each.value, "notify_no_data", null)
+  new_group_delay        = lookup(each.value, "new_host_delay", null)
+  evaluation_delay       = lookup(each.value, "evaluation_delay", null)
+  no_data_timeframe      = lookup(each.value, "no_data_timeframe", null)
+  renotify_interval      = lookup(each.value, "renotify_interval", null)
+  notify_audit           = lookup(each.value, "notify_audit", null)
+  timeout_h              = lookup(each.value, "timeout_h", null)
+  include_tags           = lookup(each.value, "include_tags", null)
+  enable_logs_sample     = lookup(each.value, "enable_logs_sample", null)
+  force_delete           = lookup(each.value, "force_delete", null)
+  priority               = lookup(each.value, "priority", null)
+  groupby_simple_monitor = lookup(each.value, "groupby_simple_monitor", null)
+  renotify_occurrences   = lookup(each.value, "renotify_occurrences", null)
+  renotify_statuses      = lookup(each.value, "renotify_statuses", null)
+  validate               = lookup(each.value, "validate", null)
+  
+  # DEPRECATED: use new_group_delay instead
+  new_host_delay = lookup(each.value, "new_host_delay", null)
 
   monitor_thresholds {
     warning           = lookup(each.value.thresholds, "warning", null)

--- a/modules/monitors/main.tf
+++ b/modules/monitors/main.tf
@@ -28,7 +28,7 @@ resource "datadog_monitor" "default" {
   renotify_occurrences   = lookup(each.value, "renotify_occurrences", null)
   renotify_statuses      = lookup(each.value, "renotify_statuses", null)
   validate               = lookup(each.value, "validate", null)
-  
+
   # DEPRECATED: use new_group_delay instead
   new_host_delay = lookup(each.value, "new_host_delay", null)
 

--- a/modules/monitors/main.tf
+++ b/modules/monitors/main.tf
@@ -14,7 +14,7 @@ resource "datadog_monitor" "default" {
   escalation_message     = lookup(each.value, "escalation_message", null)
   require_full_window    = lookup(each.value, "require_full_window", null)
   notify_no_data         = lookup(each.value, "notify_no_data", null)
-  new_group_delay        = lookup(each.value, "new_host_delay", null)
+  new_group_delay        = lookup(each.value, "new_group_delay", null)
   evaluation_delay       = lookup(each.value, "evaluation_delay", null)
   no_data_timeframe      = lookup(each.value, "no_data_timeframe", null)
   renotify_interval      = lookup(each.value, "renotify_interval", null)

--- a/modules/monitors/versions.tf
+++ b/modules/monitors/versions.tf
@@ -4,11 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.3"
+      version = ">= 3.0"
     }
     datadog = {
       source  = "datadog/datadog"

--- a/modules/permissions/versions.tf
+++ b/modules/permissions/versions.tf
@@ -4,11 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.3"
+      version = ">= 3.0"
     }
     datadog = {
       source  = "datadog/datadog"

--- a/modules/roles/versions.tf
+++ b/modules/roles/versions.tf
@@ -4,11 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.3"
+      version = ">= 3.0"
     }
     datadog = {
       source  = "datadog/datadog"

--- a/modules/synthetics/versions.tf
+++ b/modules/synthetics/versions.tf
@@ -4,11 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.3"
+      version = ">= 3.0"
     }
     datadog = {
       source  = "datadog/datadog"

--- a/versions.tf
+++ b/versions.tf
@@ -4,11 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.3"
+      version = ">= 3.0"
     }
     datadog = {
       source  = "datadog/datadog"


### PR DESCRIPTION
## what
* Monitor inputs
    * Added new_group_delay (deprecated new_host_delay)
    * Added groupby_simple_monitor
    * Added renotify_occurrences
    * Added renotify_statuses
    * Added validate
* Bumped aws provider to 3.x
* Removed unused local provider

## why
* Added additional monitor inputs

## references
* Closes https://github.com/cloudposse/terraform-datadog-platform/issues/43
* https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor
