### PR TITLE
Missing var.datadog_monitors keys

### DIFF
--- a/catalog/monitors/amq.yaml
+++ b/catalog/monitors/amq.yaml
@@ -26,6 +26,7 @@ amq-cpu-utilization:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -66,6 +67,7 @@ amq-heap-usage:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -103,6 +105,7 @@ amq-network-in:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 900
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -142,6 +145,7 @@ amq-network-out:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 900
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -181,6 +185,7 @@ amq-current-connections-count:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 900
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0

--- a/catalog/monitors/amq.yaml
+++ b/catalog/monitors/amq.yaml
@@ -29,7 +29,7 @@ amq-cpu-utilization:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -69,7 +69,7 @@ amq-heap-usage:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -106,7 +106,7 @@ amq-network-in:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows:
@@ -145,7 +145,7 @@ amq-network-out:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows:
@@ -184,7 +184,7 @@ amq-current-connections-count:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows:

--- a/catalog/monitors/amq.yaml
+++ b/catalog/monitors/amq.yaml
@@ -26,7 +26,7 @@ amq-cpu-utilization:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -62,7 +62,7 @@ amq-heap-usage:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -95,7 +95,7 @@ amq-network-in:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 900
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows:
     trigger_window: "last_15m"
@@ -130,7 +130,7 @@ amq-network-out:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 900
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows:
     trigger_window: "last_15m"
@@ -165,7 +165,7 @@ amq-current-connections-count:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 900
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows:
     trigger_window: "last_15m"

--- a/catalog/monitors/amq.yaml
+++ b/catalog/monitors/amq.yaml
@@ -26,7 +26,7 @@ amq-cpu-utilization:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -66,7 +66,7 @@ amq-heap-usage:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -103,7 +103,7 @@ amq-network-in:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 900
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -142,7 +142,7 @@ amq-network-out:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 900
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -181,7 +181,7 @@ amq-current-connections-count:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 900
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []

--- a/catalog/monitors/amq.yaml
+++ b/catalog/monitors/amq.yaml
@@ -27,6 +27,10 @@ amq-cpu-utilization:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -63,6 +67,10 @@ amq-heap-usage:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -96,6 +104,10 @@ amq-network-in:
   timeout_h: 60
   evaluation_delay: 900
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows:
     trigger_window: "last_15m"
@@ -131,6 +143,10 @@ amq-network-out:
   timeout_h: 60
   evaluation_delay: 900
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows:
     trigger_window: "last_15m"
@@ -166,6 +182,10 @@ amq-current-connections-count:
   timeout_h: 60
   evaluation_delay: 900
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows:
     trigger_window: "last_15m"

--- a/catalog/monitors/aurora.yaml
+++ b/catalog/monitors/aurora.yaml
@@ -26,7 +26,7 @@ aurora-replica-lag:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:

--- a/catalog/monitors/aurora.yaml
+++ b/catalog/monitors/aurora.yaml
@@ -27,6 +27,10 @@ aurora-replica-lag:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:

--- a/catalog/monitors/aurora.yaml
+++ b/catalog/monitors/aurora.yaml
@@ -29,7 +29,7 @@ aurora-replica-lag:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }

--- a/catalog/monitors/aurora.yaml
+++ b/catalog/monitors/aurora.yaml
@@ -26,6 +26,7 @@ aurora-replica-lag:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0

--- a/catalog/monitors/aurora.yaml
+++ b/catalog/monitors/aurora.yaml
@@ -26,7 +26,7 @@ aurora-replica-lag:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []

--- a/catalog/monitors/ec2.yaml
+++ b/catalog/monitors/ec2.yaml
@@ -21,7 +21,7 @@ ec2-failed-status-check:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []

--- a/catalog/monitors/ec2.yaml
+++ b/catalog/monitors/ec2.yaml
@@ -22,6 +22,10 @@ ec2-failed-status-check:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:

--- a/catalog/monitors/ec2.yaml
+++ b/catalog/monitors/ec2.yaml
@@ -24,7 +24,7 @@ ec2-failed-status-check:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }

--- a/catalog/monitors/ec2.yaml
+++ b/catalog/monitors/ec2.yaml
@@ -21,7 +21,7 @@ ec2-failed-status-check:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:

--- a/catalog/monitors/ec2.yaml
+++ b/catalog/monitors/ec2.yaml
@@ -21,6 +21,7 @@ ec2-failed-status-check:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0

--- a/catalog/monitors/host.yaml
+++ b/catalog/monitors/host.yaml
@@ -20,7 +20,7 @@ host-io-wait-times:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -54,7 +54,7 @@ host-disk-use:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -88,7 +88,7 @@ host-high-mem-use:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -122,7 +122,7 @@ host-high-load-avg:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []

--- a/catalog/monitors/host.yaml
+++ b/catalog/monitors/host.yaml
@@ -20,6 +20,7 @@ host-io-wait-times:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -54,6 +55,7 @@ host-disk-use:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -88,6 +90,7 @@ host-high-mem-use:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -122,6 +125,7 @@ host-high-load-avg:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0

--- a/catalog/monitors/host.yaml
+++ b/catalog/monitors/host.yaml
@@ -21,6 +21,10 @@ host-io-wait-times:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -51,6 +55,10 @@ host-disk-use:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -81,6 +89,10 @@ host-high-mem-use:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -111,6 +123,10 @@ host-high-load-avg:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:

--- a/catalog/monitors/host.yaml
+++ b/catalog/monitors/host.yaml
@@ -20,7 +20,7 @@ host-io-wait-times:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -50,7 +50,7 @@ host-disk-use:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -80,7 +80,7 @@ host-high-mem-use:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -110,7 +110,7 @@ host-high-load-avg:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:

--- a/catalog/monitors/host.yaml
+++ b/catalog/monitors/host.yaml
@@ -23,7 +23,7 @@ host-io-wait-times:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -57,7 +57,7 @@ host-disk-use:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -91,7 +91,7 @@ host-high-mem-use:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -125,7 +125,7 @@ host-high-load-avg:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }

--- a/catalog/monitors/k8s.yaml
+++ b/catalog/monitors/k8s.yaml
@@ -22,6 +22,10 @@ k8s-deployment-replica-pod-down:
   timeout_h: 0
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 5
   threshold_windows: { }
   thresholds:
@@ -48,6 +52,10 @@ k8s-pod-restarting:
   timeout_h: 0
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -75,12 +83,15 @@ k8s-statefulset-replica-down:
   timeout_h: 0
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
     warning: 1
     critical: 2
-
 
 k8s-daemonset-pod-down:
   name: "(k8s) DaemonSet Pod is down"
@@ -103,6 +114,10 @@ k8s-daemonset-pod-down:
   timeout_h: 0
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -129,6 +144,10 @@ k8s-crashloopBackOff:
   timeout_h: 0
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -155,6 +174,10 @@ k8s-multiple-pods-failing:
   timeout_h: 0
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -182,6 +205,10 @@ k8s-unavailable-deployment-replica:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -213,6 +240,10 @@ k8s-unavailable-statefulset-replica:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -244,6 +275,10 @@ k8s-node-status-unschedulable:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -275,6 +310,10 @@ k8s-imagepullbackoff:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -306,6 +345,10 @@ k8s-high-cpu-usage:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -337,6 +380,10 @@ k8s-high-disk-usage:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -373,6 +420,10 @@ k8s-high-memory-usage:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -409,6 +460,10 @@ k8s-high-filesystem-usage:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -445,6 +500,10 @@ k8s-network-tx-errors:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -481,6 +540,10 @@ k8s-network-rx-errors:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -512,6 +575,10 @@ k8s-node-not-ready:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -543,6 +610,10 @@ k8s-kube-api-down:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -574,6 +645,10 @@ k8s-increased-pod-crash:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -605,6 +680,10 @@ k8s-hpa-errors:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -637,6 +716,10 @@ k8s-pending-pods:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:

--- a/catalog/monitors/k8s.yaml
+++ b/catalog/monitors/k8s.yaml
@@ -21,7 +21,7 @@ k8s-deployment-replica-pod-down:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 5
   threshold_windows: { }
   thresholds:
@@ -47,7 +47,7 @@ k8s-pod-restarting:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -74,7 +74,7 @@ k8s-statefulset-replica-down:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -102,7 +102,7 @@ k8s-daemonset-pod-down:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -128,7 +128,7 @@ k8s-crashloopBackOff:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -154,7 +154,7 @@ k8s-multiple-pods-failing:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -181,7 +181,7 @@ k8s-unavailable-deployment-replica:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -212,7 +212,7 @@ k8s-unavailable-statefulset-replica:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -243,7 +243,7 @@ k8s-node-status-unschedulable:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -274,7 +274,7 @@ k8s-imagepullbackoff:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -305,7 +305,7 @@ k8s-high-cpu-usage:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -336,7 +336,7 @@ k8s-high-disk-usage:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -372,7 +372,7 @@ k8s-high-memory-usage:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -408,7 +408,7 @@ k8s-high-filesystem-usage:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -444,7 +444,7 @@ k8s-network-tx-errors:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -480,7 +480,7 @@ k8s-network-rx-errors:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -511,7 +511,7 @@ k8s-node-not-ready:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -542,7 +542,7 @@ k8s-kube-api-down:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -573,7 +573,7 @@ k8s-increased-pod-crash:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -604,7 +604,7 @@ k8s-hpa-errors:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -636,7 +636,7 @@ k8s-pending-pods:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:

--- a/catalog/monitors/k8s.yaml
+++ b/catalog/monitors/k8s.yaml
@@ -24,7 +24,7 @@ k8s-deployment-replica-pod-down:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 5
   threshold_windows: { }
@@ -54,7 +54,7 @@ k8s-pod-restarting:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -85,7 +85,7 @@ k8s-statefulset-replica-down:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -116,7 +116,7 @@ k8s-daemonset-pod-down:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -146,7 +146,7 @@ k8s-crashloopBackOff:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -176,7 +176,7 @@ k8s-multiple-pods-failing:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -207,7 +207,7 @@ k8s-unavailable-deployment-replica:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -242,7 +242,7 @@ k8s-unavailable-statefulset-replica:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -277,7 +277,7 @@ k8s-node-status-unschedulable:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -312,7 +312,7 @@ k8s-imagepullbackoff:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -347,7 +347,7 @@ k8s-high-cpu-usage:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -382,7 +382,7 @@ k8s-high-disk-usage:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -422,7 +422,7 @@ k8s-high-memory-usage:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -462,7 +462,7 @@ k8s-high-filesystem-usage:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -502,7 +502,7 @@ k8s-network-tx-errors:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -542,7 +542,7 @@ k8s-network-rx-errors:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -577,7 +577,7 @@ k8s-node-not-ready:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -612,7 +612,7 @@ k8s-kube-api-down:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -647,7 +647,7 @@ k8s-increased-pod-crash:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -682,7 +682,7 @@ k8s-hpa-errors:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -718,7 +718,7 @@ k8s-pending-pods:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }

--- a/catalog/monitors/k8s.yaml
+++ b/catalog/monitors/k8s.yaml
@@ -21,6 +21,7 @@ k8s-deployment-replica-pod-down:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -51,6 +52,7 @@ k8s-pod-restarting:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -82,6 +84,7 @@ k8s-statefulset-replica-down:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -113,6 +116,7 @@ k8s-daemonset-pod-down:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -143,6 +147,7 @@ k8s-crashloopBackOff:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -173,6 +178,7 @@ k8s-multiple-pods-failing:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -204,6 +210,7 @@ k8s-unavailable-deployment-replica:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -239,6 +246,7 @@ k8s-unavailable-statefulset-replica:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -274,6 +282,7 @@ k8s-node-status-unschedulable:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -309,6 +318,7 @@ k8s-imagepullbackoff:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -344,6 +354,7 @@ k8s-high-cpu-usage:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -379,6 +390,7 @@ k8s-high-disk-usage:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -419,6 +431,7 @@ k8s-high-memory-usage:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -459,6 +472,7 @@ k8s-high-filesystem-usage:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -499,6 +513,7 @@ k8s-network-tx-errors:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -539,6 +554,7 @@ k8s-network-rx-errors:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -574,6 +590,7 @@ k8s-node-not-ready:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -609,6 +626,7 @@ k8s-kube-api-down:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -644,6 +662,7 @@ k8s-increased-pod-crash:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -679,6 +698,7 @@ k8s-hpa-errors:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -715,6 +735,7 @@ k8s-pending-pods:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0

--- a/catalog/monitors/k8s.yaml
+++ b/catalog/monitors/k8s.yaml
@@ -21,7 +21,7 @@ k8s-deployment-replica-pod-down:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -51,7 +51,7 @@ k8s-pod-restarting:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -82,7 +82,7 @@ k8s-statefulset-replica-down:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -113,7 +113,7 @@ k8s-daemonset-pod-down:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -143,7 +143,7 @@ k8s-crashloopBackOff:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -173,7 +173,7 @@ k8s-multiple-pods-failing:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -204,7 +204,7 @@ k8s-unavailable-deployment-replica:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -239,7 +239,7 @@ k8s-unavailable-statefulset-replica:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -274,7 +274,7 @@ k8s-node-status-unschedulable:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -309,7 +309,7 @@ k8s-imagepullbackoff:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -344,7 +344,7 @@ k8s-high-cpu-usage:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -379,7 +379,7 @@ k8s-high-disk-usage:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -419,7 +419,7 @@ k8s-high-memory-usage:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -459,7 +459,7 @@ k8s-high-filesystem-usage:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -499,7 +499,7 @@ k8s-network-tx-errors:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -539,7 +539,7 @@ k8s-network-rx-errors:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -574,7 +574,7 @@ k8s-node-not-ready:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -609,7 +609,7 @@ k8s-kube-api-down:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -644,7 +644,7 @@ k8s-increased-pod-crash:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -679,7 +679,7 @@ k8s-hpa-errors:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -715,7 +715,7 @@ k8s-pending-pods:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []

--- a/catalog/monitors/rabbitmq.yaml
+++ b/catalog/monitors/rabbitmq.yaml
@@ -23,7 +23,7 @@ rabbitmq-messages-unacknowledged-rate-too-high:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: null
   threshold_windows: { }
   thresholds:
@@ -57,7 +57,7 @@ rabbitmq-disk-usage-too-high:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: null
   threshold_windows: { }
   thresholds:

--- a/catalog/monitors/rabbitmq.yaml
+++ b/catalog/monitors/rabbitmq.yaml
@@ -23,7 +23,7 @@ rabbitmq-messages-unacknowledged-rate-too-high:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -61,7 +61,7 @@ rabbitmq-disk-usage-too-high:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []

--- a/catalog/monitors/rabbitmq.yaml
+++ b/catalog/monitors/rabbitmq.yaml
@@ -23,6 +23,7 @@ rabbitmq-messages-unacknowledged-rate-too-high:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -61,6 +62,7 @@ rabbitmq-disk-usage-too-high:
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0

--- a/catalog/monitors/rabbitmq.yaml
+++ b/catalog/monitors/rabbitmq.yaml
@@ -26,7 +26,7 @@ rabbitmq-messages-unacknowledged-rate-too-high:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: null
   threshold_windows: { }
@@ -64,7 +64,7 @@ rabbitmq-disk-usage-too-high:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: null
   threshold_windows: { }

--- a/catalog/monitors/rabbitmq.yaml
+++ b/catalog/monitors/rabbitmq.yaml
@@ -24,6 +24,10 @@ rabbitmq-messages-unacknowledged-rate-too-high:
   timeout_h: 0
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: null
   threshold_windows: { }
   thresholds:
@@ -58,6 +62,10 @@ rabbitmq-disk-usage-too-high:
   timeout_h: 0
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: null
   threshold_windows: { }
   thresholds:

--- a/catalog/monitors/rds.yaml
+++ b/catalog/monitors/rds.yaml
@@ -26,7 +26,7 @@ rds-cpuutilization:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -62,7 +62,7 @@ rds-disk-queue-depth:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -98,7 +98,7 @@ rds-freeable-memory:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -134,7 +134,7 @@ rds-swap-usage:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -170,7 +170,7 @@ rds-database-connections:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows:
     trigger_window: "last_15m"

--- a/catalog/monitors/rds.yaml
+++ b/catalog/monitors/rds.yaml
@@ -26,6 +26,7 @@ rds-cpuutilization:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -66,6 +67,7 @@ rds-disk-queue-depth:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -106,6 +108,7 @@ rds-freeable-memory:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -146,6 +149,7 @@ rds-swap-usage:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -186,6 +190,7 @@ rds-database-connections:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0

--- a/catalog/monitors/rds.yaml
+++ b/catalog/monitors/rds.yaml
@@ -26,7 +26,7 @@ rds-cpuutilization:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -66,7 +66,7 @@ rds-disk-queue-depth:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -106,7 +106,7 @@ rds-freeable-memory:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -146,7 +146,7 @@ rds-swap-usage:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -186,7 +186,7 @@ rds-database-connections:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []

--- a/catalog/monitors/rds.yaml
+++ b/catalog/monitors/rds.yaml
@@ -29,7 +29,7 @@ rds-cpuutilization:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -69,7 +69,7 @@ rds-disk-queue-depth:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -109,7 +109,7 @@ rds-freeable-memory:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -149,7 +149,7 @@ rds-swap-usage:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -189,7 +189,7 @@ rds-database-connections:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows:

--- a/catalog/monitors/rds.yaml
+++ b/catalog/monitors/rds.yaml
@@ -27,6 +27,10 @@ rds-cpuutilization:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -63,6 +67,10 @@ rds-disk-queue-depth:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -99,6 +107,10 @@ rds-freeable-memory:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -135,6 +147,10 @@ rds-swap-usage:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -171,6 +187,10 @@ rds-database-connections:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows:
     trigger_window: "last_15m"

--- a/catalog/monitors/redshift.yaml
+++ b/catalog/monitors/redshift.yaml
@@ -23,7 +23,7 @@ redshift-health-status:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -56,7 +56,7 @@ redshift-database-connections:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows:
     trigger_window: "last_15m"
@@ -94,7 +94,7 @@ redshift-cpuutilization:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -130,7 +130,7 @@ redshift-write-latency:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -166,7 +166,7 @@ redshift-disk-space-used:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -199,7 +199,7 @@ redshift-network-receive:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows:
     trigger_window: "last_15m"
@@ -234,7 +234,7 @@ redshift-network-transmit:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows:
     trigger_window: "last_15m"
@@ -269,7 +269,7 @@ redshift-read-throughput:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows:
     trigger_window: "last_15m"
@@ -304,7 +304,7 @@ redshift-write-throughput:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_host_delay: 300
+  new_group_delay: 300
   no_data_timeframe: 10
   threshold_windows:
     trigger_window: "last_15m"

--- a/catalog/monitors/redshift.yaml
+++ b/catalog/monitors/redshift.yaml
@@ -23,7 +23,7 @@ redshift-health-status:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -60,7 +60,7 @@ redshift-database-connections:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -102,7 +102,7 @@ redshift-cpuutilization:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -142,7 +142,7 @@ redshift-write-latency:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -182,7 +182,7 @@ redshift-disk-space-used:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -219,7 +219,7 @@ redshift-network-receive:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -258,7 +258,7 @@ redshift-network-transmit:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -297,7 +297,7 @@ redshift-read-throughput:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []
@@ -336,7 +336,7 @@ redshift-write-throughput:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
-  new_group_delay: 300
+  new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
   renotify_statuses: []

--- a/catalog/monitors/redshift.yaml
+++ b/catalog/monitors/redshift.yaml
@@ -26,7 +26,7 @@ redshift-health-status:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -63,7 +63,7 @@ redshift-database-connections:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows:
@@ -105,7 +105,7 @@ redshift-cpuutilization:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -145,7 +145,7 @@ redshift-write-latency:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -185,7 +185,7 @@ redshift-disk-space-used:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows: { }
@@ -222,7 +222,7 @@ redshift-network-receive:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows:
@@ -261,7 +261,7 @@ redshift-network-transmit:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows:
@@ -300,7 +300,7 @@ redshift-read-throughput:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows:
@@ -339,7 +339,7 @@ redshift-write-throughput:
   new_group_delay: 300
   groupby_simple_monitor: false
   renotify_occurrences: 0
-  renotify_statuses: [ "alert" ]
+  renotify_statuses: []
   validate: true
   no_data_timeframe: 10
   threshold_windows:

--- a/catalog/monitors/redshift.yaml
+++ b/catalog/monitors/redshift.yaml
@@ -23,6 +23,7 @@ redshift-health-status:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -60,6 +61,7 @@ redshift-database-connections:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -102,6 +104,7 @@ redshift-cpuutilization:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -142,6 +145,7 @@ redshift-write-latency:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -182,6 +186,7 @@ redshift-disk-space-used:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -219,6 +224,7 @@ redshift-network-receive:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -258,6 +264,7 @@ redshift-network-transmit:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -297,6 +304,7 @@ redshift-read-throughput:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0
@@ -336,6 +344,7 @@ redshift-write-throughput:
   renotify_interval: 60
   timeout_h: 60
   evaluation_delay: 60
+  new_host_delay: 300
   new_group_delay: 0
   groupby_simple_monitor: false
   renotify_occurrences: 0

--- a/catalog/monitors/redshift.yaml
+++ b/catalog/monitors/redshift.yaml
@@ -24,6 +24,10 @@ redshift-health-status:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -57,6 +61,10 @@ redshift-database-connections:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows:
     trigger_window: "last_15m"
@@ -95,6 +103,10 @@ redshift-cpuutilization:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -131,6 +143,10 @@ redshift-write-latency:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -167,6 +183,10 @@ redshift-disk-space-used:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows: { }
   thresholds:
@@ -200,6 +220,10 @@ redshift-network-receive:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows:
     trigger_window: "last_15m"
@@ -235,6 +259,10 @@ redshift-network-transmit:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows:
     trigger_window: "last_15m"
@@ -270,6 +298,10 @@ redshift-read-throughput:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows:
     trigger_window: "last_15m"
@@ -305,6 +337,10 @@ redshift-write-throughput:
   timeout_h: 60
   evaluation_delay: 60
   new_group_delay: 300
+  groupby_simple_monitor: false
+  renotify_occurrences: 0
+  renotify_statuses: [ "alert" ]
+  validate: true
   no_data_timeframe: 10
   threshold_windows:
     trigger_window: "last_15m"

--- a/modules/monitors/main.tf
+++ b/modules/monitors/main.tf
@@ -29,9 +29,6 @@ resource "datadog_monitor" "default" {
   renotify_statuses      = lookup(each.value, "renotify_statuses", null)
   validate               = lookup(each.value, "validate", null)
 
-  # DEPRECATED: use new_group_delay instead
-  new_host_delay = lookup(each.value, "new_host_delay", null)
-
   monitor_thresholds {
     warning           = lookup(each.value.thresholds, "warning", null)
     warning_recovery  = lookup(each.value.thresholds, "warning_recovery", null)

--- a/modules/monitors/main.tf
+++ b/modules/monitors/main.tf
@@ -29,6 +29,9 @@ resource "datadog_monitor" "default" {
   renotify_statuses      = lookup(each.value, "renotify_statuses", null)
   validate               = lookup(each.value, "validate", null)
 
+  # DEPRECATED: use new_group_delay instead
+  new_host_delay = lookup(each.value, "new_host_delay", null)
+
   monitor_thresholds {
     warning           = lookup(each.value.thresholds, "warning", null)
     warning_recovery  = lookup(each.value.thresholds, "warning_recovery", null)

--- a/modules/monitors/variables.tf
+++ b/modules/monitors/variables.tf
@@ -1,27 +1,32 @@
 # https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor
 variable "datadog_monitors" {
   type = map(object({
-    name                = string
-    type                = string
-    message             = string
-    escalation_message  = string
-    query               = string
-    tags                = list(string)
-    notify_no_data      = bool
-    new_host_delay      = number
-    evaluation_delay    = number
-    no_data_timeframe   = number
-    renotify_interval   = number
-    notify_audit        = bool
-    timeout_h           = number
-    enable_logs_sample  = bool
-    include_tags        = bool
-    require_full_window = bool
-    locked              = bool
-    force_delete        = bool
-    threshold_windows   = map(any)
-    thresholds          = map(any)
-    priority            = number
+    name                   = string
+    type                   = string
+    message                = string
+    escalation_message     = string
+    query                  = string
+    tags                   = list(string)
+    notify_no_data         = bool
+    new_host_delay         = number
+    new_group_delay        = number
+    evaluation_delay       = number
+    no_data_timeframe      = number
+    renotify_interval      = number
+    renotify_occurrences   = number
+    renotify_statuses      = set(string)
+    notify_audit           = bool
+    timeout_h              = number
+    enable_logs_sample     = bool
+    include_tags           = bool
+    require_full_window    = bool
+    locked                 = bool
+    force_delete           = bool
+    threshold_windows      = map(any)
+    thresholds             = map(any)
+    priority               = number
+    groupby_simple_monitor = bool
+    validate               = bool
   }))
   description = "Map of Datadog monitor configurations. See catalog for examples"
 }

--- a/modules/monitors/variables.tf
+++ b/modules/monitors/variables.tf
@@ -26,6 +26,10 @@ variable "datadog_monitors" {
     priority               = number
     groupby_simple_monitor = bool
     validate               = bool
+
+    # TODO: deprecate in favor of new_group_delay once the options are fully clarified
+    # See https://github.com/DataDog/terraform-provider-datadog/issues/1292
+    new_host_delay = number
   }))
   description = "Map of Datadog monitor configurations. See catalog for examples"
 }

--- a/modules/monitors/variables.tf
+++ b/modules/monitors/variables.tf
@@ -8,7 +8,6 @@ variable "datadog_monitors" {
     query                  = string
     tags                   = list(string)
     notify_no_data         = bool
-    new_host_delay         = number
     new_group_delay        = number
     evaluation_delay       = number
     no_data_timeframe      = number


### PR DESCRIPTION
## what
* Added missing keys to `var.datadog_monitors`
    * Added `new_group_delay` as `number`
    * Added `groupby_simple_monitor` as `bool`
    * Added `renotify_occurrences` as `number`
    * Added `renotify_statuses` as `set(string)`
    * Added `validate` as `bool`

* ~Removal of `new_host_delay` in favor of `new_group_delay` but `new_group_delay` has to be set to `0` since none of the alerts in our catalogs are multi-monitor. See https://github.com/DataDog/terraform-provider-datadog/issues/1221#issuecomment-931006926. Apparently `new_host_delay` has zero effect for non multi monitor alerts.~
    ```
    Error: error validating monitor from https://api.datadoghq.com/api/v1/monitor/validate: 400 Bad Request: {"errors": ["The new_group_delay option can only be used for multi-alert monitors"]}
    ```

## why
* The lookups for the previously added keys will always return null unless the input var supports those same keys
* new_host_delay was not deprecated due to confusion in the docs. Safer to keep this as-is until we have more information.

## references
* Previous PR https://github.com/cloudposse/terraform-datadog-platform/pull/51
* Clarify confusion between new_host_delay and new_group_delay
    * https://github.com/DataDog/terraform-provider-datadog/issues/1292
    * Multi alert examples https://docs.datadoghq.com/monitors/create/types/composite/#common-reporting-sources
* cc: @bateller

