### PR TITLE
Synthetics Use tags as map

### DIFF
--- a/examples/synthetics/catalog/http.yaml
+++ b/examples/synthetics/catalog/http.yaml
@@ -4,7 +4,7 @@ simple:
   type: api
   subtype: http
   tags:
-    - "ManagedBy:Terraform"
+    ManagedBy: Terraform
   locations:
     - "aws:us-west-2"
   status: "live"

--- a/examples/synthetics/catalog/ssl.yaml
+++ b/examples/synthetics/catalog/ssl.yaml
@@ -4,7 +4,7 @@ ssl-test:
   type: api
   subtype: ssl
   tags:
-    - "ManagedBy:Terraform"
+    ManagedBy: Terraform
   locations:
     - "aws:us-west-2"
   status: "live"

--- a/modules/synthetics/main.tf
+++ b/modules/synthetics/main.tf
@@ -18,6 +18,13 @@ resource "datadog_synthetics_test" "default" {
   # Optional
   message = lookup(each.value, "message", null) != null ? format("%s%s", each.value.message, local.alert_tags) : null
   subtype = lookup(each.value, "subtype", null)
+  # convert terraform tags map to datadog tags list
+  # if a key is supplied with a value, it will render "key:value" as a tag
+  #   tags:
+  #     key = value
+  # if a key is supplied without a value (null), it will render "key" as a tag
+  #   tags:
+  #     key = null
   tags = [
     for tagk, tagv in lookup(each.value, "tags", module.this.tags) :
     tagv != null ? format("%s:%s", tagk, tagv) : tagk

--- a/modules/synthetics/main.tf
+++ b/modules/synthetics/main.tf
@@ -16,9 +16,12 @@ resource "datadog_synthetics_test" "default" {
   locations = try(each.value.locations, var.locations)
 
   # Optional
-  message         = lookup(each.value, "message", null) != null ? format("%s%s", each.value.message, local.alert_tags) : null
-  subtype         = lookup(each.value, "subtype", null)
-  tags            = lookup(each.value, "tags", module.this.tags)
+  message = lookup(each.value, "message", null) != null ? format("%s%s", each.value.message, local.alert_tags) : null
+  subtype = lookup(each.value, "subtype", null)
+  tags = [
+    for tagk, tagv in lookup(each.value, "tags", module.this.tags) :
+    tagv != null ? format("%s:%s", tagk, tagv) : tagk
+  ]
   request_headers = lookup(each.value, "request_headers", null)
   request_query   = lookup(each.value, "request_query", null)
   set_cookie      = lookup(each.value, "set_cookie", null)


### PR DESCRIPTION
## what
* match synthetics to monitors, where tags are now an array from map

## why
* Allows us to merge tags from yaml and insert them into synthetics via DD Format

## references
 #53 

