### PR TITLE
Fix `child_organization` outputs

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -47,7 +47,7 @@ template: |
 
 replacers:
 # Remove irrelevant information from Renovate bot
-- search: '/(?<=---\s+)+^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
+- search: '/(?<=---\s)\s*^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
   replace: ''
 # Remove Renovate bot banner image
 - search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017-2021 Cloud Posse, LLC
+   Copyright 2017-2022 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/modules/child_organization/outputs.tf
+++ b/modules/child_organization/outputs.tf
@@ -14,23 +14,23 @@ output "public_id" {
 }
 
 output "user" {
-  value       = try(datadog_child_organization.default[0].user, {})
+  value       = try(datadog_child_organization.default[0].user[0], {})
   description = "Information about organization users"
 }
 
 output "settings" {
-  value       = try(datadog_child_organization.default[0].settings, {})
+  value       = try(datadog_child_organization.default[0].settings[0], {})
   description = "Organization settings"
 }
 
 output "api_key" {
-  value       = try(datadog_child_organization.default[0].api_key, {})
+  value       = try(datadog_child_organization.default[0].api_key[0], {})
   description = "Information about Datadog API key"
   sensitive   = true
 }
 
 output "application_key" {
-  value       = try(datadog_child_organization.default[0].application_key, {})
+  value       = try(datadog_child_organization.default[0].application_key[0], {})
   description = "Datadog application key with its associated metadata"
   sensitive   = true
 }


### PR DESCRIPTION
## what
* Fix `child_organization` outputs

## why
* Those outputs are not objects, but lists of objects with one item

## references
* https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/child_organization

