### PR TITLE
Module Synthetics - Public Locations only from `all`

### DIFF
--- a/.github/workflows/auto-readme.yml
+++ b/.github/workflows/auto-readme.yml
@@ -1,5 +1,7 @@
 name: "auto-readme"
 on:
+  workflow_dispatch:
+
   schedule:
   # Example of job definition:
   # .---------------- minute (0 - 59)
@@ -15,21 +17,35 @@ on:
 
 jobs:
   update:
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
+    - name: Find default branch name
+      id: defaultBranch
+      shell: bash
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
+        printf "::set-output name=defaultBranch::%s\n" "${default_branch}"
+        printf "defaultBranchRef.name=%s\n" "${default_branch}"
 
     - name: Update readme
       shell: bash
       id: update
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        DEF: "${{ steps.defaultBranch.outputs.defaultBranch }}"
       run: |
         make init
         make readme/build
         # Ignore changes if they are only whitespace
-        git diff --ignore-all-space --ignore-blank-lines --quiet README.md && { git restore README.md; echo Ignoring whitespace-only changes in README; }
+        if ! git diff --quiet README.md && git diff --ignore-all-space --ignore-blank-lines --quiet README.md; then
+          git restore README.md
+          echo Ignoring whitespace-only changes in README
+        fi
 
     - name: Create Pull Request
       # This action will not create or change a pull request if there are no changes to make.
@@ -47,7 +63,7 @@ jobs:
           To have most recent changes of README.md and doc from origin templates
 
         branch: auto-update/readme
-        base: main
+        base: ${{ steps.defaultBranch.outputs.defaultBranch }}
         delete-branch: true
         labels: |
           auto-update

--- a/modules/synthetics/main.tf
+++ b/modules/synthetics/main.tf
@@ -5,7 +5,7 @@ locals {
   alert_tags         = local.enabled && var.alert_tags != null ? format("%s%s", var.alert_tags_separator, join(var.alert_tags_separator, var.alert_tags)) : ""
   datadog_synthetics = { for k, v in var.datadog_synthetics : k => v if local.enabled }
 
-  all_public_locations = sort(keys({ for k,v in data.datadog_synthetics_locations.public_locations.locations : k=> v if !(length(regexall(".*pl:.*", k)) > 0)}))
+  all_public_locations = sort(keys({ for k, v in data.datadog_synthetics_locations.public_locations.locations : k => v if ! (length(regexall(".*pl:.*", k)) > 0) }))
 }
 
 data "datadog_synthetics_locations" "public_locations" {}

--- a/modules/synthetics/main.tf
+++ b/modules/synthetics/main.tf
@@ -5,7 +5,7 @@ locals {
   alert_tags         = local.enabled && var.alert_tags != null ? format("%s%s", var.alert_tags_separator, join(var.alert_tags_separator, var.alert_tags)) : ""
   datadog_synthetics = { for k, v in var.datadog_synthetics : k => v if local.enabled }
 
-  all_public_locations = sort(keys(data.datadog_synthetics_locations.public_locations.locations))
+  all_public_locations = sort(keys({ for k,v in data.datadog_synthetics_locations.public_locations.locations : k=> v if !(length(regexall(".*pl:.*", k)) > 0)}))
 }
 
 data "datadog_synthetics_locations" "public_locations" {}


### PR DESCRIPTION
## what
* Datadog Synthetics should use location all if they want all public locations.
* Datadog Synthetics should use the var locations via remote state to append private locations

## why
* The datadog datasource always fetches all available locations including all private locations. this means we could test an internal to 1 cluster address from all cluster private locations. Instead we want `all` to represent all public locations. this filters out fetched private locations.


