### PR TITLE
Use a valid default for `timeout_h`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,9 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
+  "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
     "ignorePaths": ["**/context.tf", "examples/**"]
   }
 }
-

--- a/catalog/monitors/amq.yaml
+++ b/catalog/monitors/amq.yaml
@@ -25,7 +25,7 @@ amq-cpu-utilization:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -67,7 +67,7 @@ amq-heap-usage:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -106,7 +106,7 @@ amq-network-in:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 900
   new_host_delay: 300
   new_group_delay: 0
@@ -147,7 +147,7 @@ amq-network-out:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 900
   new_host_delay: 300
   new_group_delay: 0
@@ -188,7 +188,7 @@ amq-current-connections-count:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 900
   new_host_delay: 300
   new_group_delay: 0

--- a/catalog/monitors/aurora.yaml
+++ b/catalog/monitors/aurora.yaml
@@ -25,7 +25,7 @@ aurora-replica-lag:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0

--- a/catalog/monitors/ec2.yaml
+++ b/catalog/monitors/ec2.yaml
@@ -20,7 +20,7 @@ ec2-failed-status-check:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0

--- a/catalog/monitors/host.yaml
+++ b/catalog/monitors/host.yaml
@@ -19,7 +19,7 @@ host-io-wait-times:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -55,7 +55,7 @@ host-disk-use:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -91,7 +91,7 @@ host-high-mem-use:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -127,7 +127,7 @@ host-high-load-avg:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0

--- a/catalog/monitors/k8s.yaml
+++ b/catalog/monitors/k8s.yaml
@@ -215,7 +215,7 @@ k8s-unavailable-deployment-replica:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -252,7 +252,7 @@ k8s-unavailable-statefulset-replica:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -289,7 +289,7 @@ k8s-node-status-unschedulable:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -326,7 +326,7 @@ k8s-imagepullbackoff:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -363,7 +363,7 @@ k8s-high-cpu-usage:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -400,7 +400,7 @@ k8s-high-disk-usage:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -442,7 +442,7 @@ k8s-high-memory-usage:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -484,7 +484,7 @@ k8s-high-filesystem-usage:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -526,7 +526,7 @@ k8s-network-tx-errors:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -568,7 +568,7 @@ k8s-network-rx-errors:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -605,7 +605,7 @@ k8s-node-not-ready:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -642,7 +642,7 @@ k8s-kube-api-down:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -679,7 +679,7 @@ k8s-increased-pod-crash:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -719,7 +719,7 @@ k8s-hpa-errors:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -757,7 +757,7 @@ k8s-pending-pods:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0

--- a/catalog/monitors/rds.yaml
+++ b/catalog/monitors/rds.yaml
@@ -25,7 +25,7 @@ rds-cpuutilization:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -67,7 +67,7 @@ rds-disk-queue-depth:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -109,7 +109,7 @@ rds-freeable-memory:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -151,7 +151,7 @@ rds-swap-usage:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -193,7 +193,7 @@ rds-database-connections:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0

--- a/catalog/monitors/redshift.yaml
+++ b/catalog/monitors/redshift.yaml
@@ -22,7 +22,7 @@ redshift-health-status:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -61,7 +61,7 @@ redshift-database-connections:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -105,7 +105,7 @@ redshift-cpuutilization:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -147,7 +147,7 @@ redshift-write-latency:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -189,7 +189,7 @@ redshift-disk-space-used:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -228,7 +228,7 @@ redshift-network-receive:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -269,7 +269,7 @@ redshift-network-transmit:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -310,7 +310,7 @@ redshift-read-throughput:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0
@@ -351,7 +351,7 @@ redshift-write-throughput:
   include_tags: true
   locked: false
   renotify_interval: 60
-  timeout_h: 60
+  timeout_h: 0
   evaluation_delay: 60
   new_host_delay: 300
   new_group_delay: 0


### PR DESCRIPTION
## what
* Use a valid default for `timeout_h`

## why
* Fixes datadog's deprecation of `timeout_h` greater than `24`
* Reason why `0` was chosen is because for some monitors `0` is already used

## references
- Closes https://github.com/cloudposse/terraform-datadog-platform/issues/63
- Where `timeout_h: 0` is used https://github.com/cloudposse/terraform-datadog-platform/blob/ea139d01e4cad78a446552c6174ee7ac3f888c67/catalog/monitors/k8s.yaml#L23
- https://docs.datadoghq.com/monitors/guide/monitor_api_options/
- https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor#timeout_h

