### PR TITLE
Fix:  Inconsistent conditional result types

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,6 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.0.0 |
 
 ## Providers

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,7 +4,6 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.0.0 |
 
 ## Providers

--- a/modules/monitors/main.tf
+++ b/modules/monitors/main.tf
@@ -6,7 +6,7 @@ locals {
 
 # https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor
 resource "datadog_monitor" "default" {
-  for_each = local.enabled ? { for k, v in var.datadog_monitors : k => v if lookup(v, "enabled", true) } : {}
+  for_each =  { for k, v in var.datadog_monitors : k => v if local.enabled && lookup(v, "enabled", true) }
 
   name                   = each.value.name
   type                   = each.value.type

--- a/modules/monitors/main.tf
+++ b/modules/monitors/main.tf
@@ -6,7 +6,7 @@ locals {
 
 # https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor
 resource "datadog_monitor" "default" {
-  for_each =  { for k, v in var.datadog_monitors : k => v if local.enabled && lookup(v, "enabled", true) }
+  for_each = { for k, v in var.datadog_monitors : k => v if local.enabled && lookup(v, "enabled", true) }
 
   name                   = each.value.name
   type                   = each.value.type

--- a/modules/monitors/versions.tf
+++ b/modules/monitors/versions.tf
@@ -1,11 +1,7 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.0"
 
   required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 3.0"
-    }
     datadog = {
       source  = "datadog/datadog"
       version = ">= 3.0.0"

--- a/modules/monitors/versions.tf
+++ b/modules/monitors/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
     datadog = {

--- a/versions.tf
+++ b/versions.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 3.0"
-    }
     datadog = {
       source  = "datadog/datadog"
       version = ">= 3.0.0"


### PR DESCRIPTION
## what
* Fixes the error where terraform expects both sides of ternary to be same complex type/elements.

## why
* When adding multiple monitors with different requirements, terraform complains that the object does not match throughout the compiled map.

```
locals {
  datadog_monitors = {
    test-object-1 = {
      name                = "test-object-1"
      message             = "test-object-1"
      type                = "metric alert"
      query               = "avg(last_30m):avg:system.load.norm.5{*} by {host} > 2"
      require_full_window = true
      threshold_windows   = {}
      thresholds = {
        critical = 2
      }
    }
    test-object-2 = {
      name              = "test-object-2"
      message           = "test-object-2"
      type              = "metric alert"
      query             = "avg(last_30m):avg:system.load.norm.5{*} by {host} > 2"
      threshold_windows = {}
      thresholds = {
        critical = 2
      }
    }
  }
}
```

```
│ Error: Inconsistent conditional result types
│
│   on .modules/monitors/main.tf line 9, in resource "datadog_monitor" "default":
│    9:   for_each = local.enabled ? { for k, v in var.datadog_monitors : k => v if lookup(v, "enabled", true) } : {}
│     ├────────────────
│     │ local.enabled is true
│     │ var.datadog_monitors is object with 2 attributes
│
│ The true and false result expressions must have consistent types. The
│ 'true' value includes object attribute "test-object-1", which is absent in
│ the 'false' value.
```

## references
* Use suggestion made by @aknysh in `#58` https://github.com/cloudposse/terraform-datadog-platform/pull/58#discussion_r804290888
* May be related to/fix the issue brought up in #66

