### PR TITLE
fix: updated lookup for thresholds in monitor slo to.

### DIFF
--- a/modules/slo/monitor_slo.tf
+++ b/modules/slo/monitor_slo.tf
@@ -24,9 +24,9 @@ resource "datadog_service_level_objective" "monitor_slo" {
   dynamic "thresholds" {
     for_each = each.value.thresholds
     content {
-      target    = lookup(thresholds, "target", "99.00")
-      timeframe = lookup(thresholds, "timeframe", "7d")
-      warning   = lookup(thresholds, "warning", "99.95")
+      target    = lookup(thresholds.value, "target", "99.00")
+      timeframe = lookup(thresholds.value, "timeframe", "7d")
+      warning   = lookup(thresholds.value, "warning", "99.95")
     }
   }
 


### PR DESCRIPTION
## what
* lookup function did not pull the correct value required for thresholds, and instead went to the default. 
    * This resulted in an error when creating an SLO of type `monitor` when using more then one threshold. 

## why
* We are creating all of our metrics, monitors, SLOs, etc with IaC, using cloud posse's modules (thanks!)


