### PR TITLE
Added scheduling options

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,6 @@ We highly recommend that in your code you pin the version to the exact version y
 using so that your infrastructure remains stable, and update versions in a
 systematic way so that they do not catch you by surprise.
 
-Also, because of a bug in the Terraform registry ([hashicorp/terraform#21417](https://github.com/hashicorp/terraform/issues/21417)),
-the registry shows many of our inputs as required when in fact they are optional.
-The table below correctly indicates which inputs are required.
-
 
 
 Provision Datadog monitors from the catalog of YAML definitions:

--- a/examples/rbac/main.tf
+++ b/examples/rbac/main.tf
@@ -1,6 +1,6 @@
 module "monitor_configs" {
   source  = "cloudposse/config/yaml"
-  version = "0.8.1"
+  version = "1.0.2"
 
   map_config_local_base_path = path.module
   map_config_paths           = var.monitor_paths
@@ -10,7 +10,7 @@ module "monitor_configs" {
 
 module "role_configs" {
   source  = "cloudposse/config/yaml"
-  version = "0.8.1"
+  version = "1.0.2"
 
   map_config_local_base_path = path.module
   map_config_paths           = var.role_paths

--- a/modules/monitors/main.tf
+++ b/modules/monitors/main.tf
@@ -47,6 +47,20 @@ resource "datadog_monitor" "default" {
     trigger_window  = lookup(each.value.threshold_windows, "trigger_window", null)
   }
 
+  dynamic "scheduling_options" {
+    for_each = lookup(each.value, "scheduling_options", [])
+    content {
+      dynamic "evaluation_window" {
+        for_each = lookup(scheduling_options.value, "evaluation_window", [])
+        content {
+          day_starts   = lookup(evaluation_window.value, "day_starts", null)
+          hour_starts  = lookup(evaluation_window.value, "hour_starts", null)
+          month_starts = lookup(evaluation_window.value, "month_starts", null)
+        }
+      }
+    }
+  }
+
   # Assign restricted roles
   # Only these roles will have access to the monitor according to their permissions
   restricted_roles = try(var.restricted_roles_map[each.key], null)

--- a/modules/monitors/versions.tf
+++ b/modules/monitors/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 3.0.0"
+      version = ">= 3.18.0"
     }
   }
 }

--- a/modules/synthetics/main.tf
+++ b/modules/synthetics/main.tf
@@ -4,7 +4,7 @@ locals {
   enabled    = module.this.enabled
   alert_tags = local.enabled && var.alert_tags != null ? format("%s%s", var.alert_tags_separator, join(var.alert_tags_separator, var.alert_tags)) : ""
 
-  all_public_locations = sort(keys({ for k, v in data.datadog_synthetics_locations.public_locations.locations : k => v if ! (length(regexall(".*pl:.*", k)) > 0) }))
+  all_public_locations = sort(keys({ for k, v in data.datadog_synthetics_locations.public_locations.locations : k => v if !(length(regexall(".*pl:.*", k)) > 0) }))
 }
 
 data "datadog_synthetics_locations" "public_locations" {}


### PR DESCRIPTION
## what

Added support for `scheduling_options`

Should be used like this:

```
k8s-no-data-from-cronjob:
  type: "query alert"
  query: "..."
  message: "..."
  ...
  scheduling_options:
    - evaluation_window:
        - day_starts: "07:00"
```

## why

Added support for `scheduling_options`

## references

- https://registry.terraform.io/providers/DataDog/datadog/3.18.0/docs/resources/monitor#scheduling_options
