### PR TITLE
Add notify by

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ resource "datadog_monitor" "default" {
   enable_logs_sample  = lookup(each.value, "enable_logs_sample", null)
   force_delete        = lookup(each.value, "force_delete", null)
   notify_by           = lookup(each.value, "notify_by", [])
+  on_missing_data     = lookup(each.value, "on_missing_data", null)
 
   monitor_thresholds {
     warning           = lookup(each.value.thresholds, "warning", null)

--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,7 @@ resource "datadog_monitor" "default" {
   include_tags        = lookup(each.value, "include_tags", null)
   enable_logs_sample  = lookup(each.value, "enable_logs_sample", null)
   force_delete        = lookup(each.value, "force_delete", null)
+  notify_by           = lookup(each.value, "notify_by", [])
 
   monitor_thresholds {
     warning           = lookup(each.value.thresholds, "warning", null)

--- a/modules/monitors/main.tf
+++ b/modules/monitors/main.tf
@@ -30,6 +30,7 @@ resource "datadog_monitor" "default" {
   renotify_statuses      = lookup(each.value, "renotify_statuses", null)
   validate               = lookup(each.value, "validate", null)
   notify_by              = lookup(each.value, "notify_by", [])
+  on_missing_data        = lookup(each.value, "on_missing_data", null)
 
   # DEPRECATED: use new_group_delay instead
   new_host_delay = lookup(each.value, "new_host_delay", null)

--- a/modules/monitors/main.tf
+++ b/modules/monitors/main.tf
@@ -29,6 +29,7 @@ resource "datadog_monitor" "default" {
   renotify_occurrences   = lookup(each.value, "renotify_occurrences", null)
   renotify_statuses      = lookup(each.value, "renotify_statuses", null)
   validate               = lookup(each.value, "validate", null)
+  notify_by              = lookup(each.value, "notify_by", [])
 
   # DEPRECATED: use new_group_delay instead
   new_host_delay = lookup(each.value, "new_host_delay", null)

--- a/modules/monitors/variables.tf
+++ b/modules/monitors/variables.tf
@@ -27,6 +27,7 @@ variable "datadog_monitors" {
   #    priority               = number
   #    groupby_simple_monitor = bool
   #    validate               = bool
+  #    notify_by              = list(string)
 
   # TODO: deprecate in favor of new_group_delay once the options are fully clarified
   # See https://github.com/DataDog/terraform-provider-datadog/issues/1292

--- a/modules/monitors/variables.tf
+++ b/modules/monitors/variables.tf
@@ -28,6 +28,7 @@ variable "datadog_monitors" {
   #    groupby_simple_monitor = bool
   #    validate               = bool
   #    notify_by              = list(string)
+  #    on_missing_data        = string
 
   # TODO: deprecate in favor of new_group_delay once the options are fully clarified
   # See https://github.com/DataDog/terraform-provider-datadog/issues/1292

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,7 @@ variable "datadog_monitors" {
     force_delete        = bool
     threshold_windows   = map(any)
     thresholds          = map(any)
+    notify_by           = list(string)
   }))
   description = "Map of Datadog monitor configurations. See catalog for examples"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,7 @@ variable "datadog_monitors" {
     threshold_windows   = map(any)
     thresholds          = map(any)
     notify_by           = list(string)
+    on_missing_data     = string
   }))
   description = "Map of Datadog monitor configurations. See catalog for examples"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 3.0.0"
+      version = ">= 3.1.0"
     }
   }
 }


### PR DESCRIPTION
## what

Add 2 new variables to monitors:
- notify_by
- on_missing_data

## why

These variables are very useful for multi alert monitors

## references

https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor#notify_by
https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor#on_missing_data