### PR TITLE
Fix: add missing inputs to datadog_monitor resource, update datadog_monitors var to use map(any)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,7 @@ resource "datadog_monitor" "default" {
 
   name                = each.value.name
   type                = each.value.type
+  priority            = lookup(each.value, "priority", null)
   query               = each.value.query
   message             = format("%s%s", each.value.message, local.alert_tags)
   escalation_message  = lookup(each.value, "escalation_message", null)

--- a/main.tf
+++ b/main.tf
@@ -9,8 +9,8 @@ resource "datadog_monitor" "default" {
 
   name                   = each.value.name
   type                   = each.value.type
-  priority               = lookup(each.value, "priority", null)
   query                  = each.value.query
+  priority               = lookup(each.value, "priority", null)
   message                = format("%s%s", each.value.message, local.alert_tags)
   escalation_message     = lookup(each.value, "escalation_message", null)
   require_full_window    = lookup(each.value, "require_full_window", null)

--- a/main.tf
+++ b/main.tf
@@ -7,23 +7,28 @@ locals {
 resource "datadog_monitor" "default" {
   for_each = local.enabled ? var.datadog_monitors : {}
 
-  name                = each.value.name
-  type                = each.value.type
-  priority            = lookup(each.value, "priority", null)
-  query               = each.value.query
-  message             = format("%s%s", each.value.message, local.alert_tags)
-  escalation_message  = lookup(each.value, "escalation_message", null)
-  require_full_window = lookup(each.value, "require_full_window", null)
-  notify_no_data      = lookup(each.value, "notify_no_data", null)
-  new_host_delay      = lookup(each.value, "new_host_delay", null)
-  evaluation_delay    = lookup(each.value, "evaluation_delay", null)
-  no_data_timeframe   = lookup(each.value, "no_data_timeframe", null)
-  renotify_interval   = lookup(each.value, "renotify_interval", null)
-  notify_audit        = lookup(each.value, "notify_audit", null)
-  timeout_h           = lookup(each.value, "timeout_h", null)
-  include_tags        = lookup(each.value, "include_tags", null)
-  enable_logs_sample  = lookup(each.value, "enable_logs_sample", null)
-  force_delete        = lookup(each.value, "force_delete", null)
+  name                   = each.value.name
+  type                   = each.value.type
+  priority               = lookup(each.value, "priority", null)
+  query                  = each.value.query
+  message                = format("%s%s", each.value.message, local.alert_tags)
+  escalation_message     = lookup(each.value, "escalation_message", null)
+  require_full_window    = lookup(each.value, "require_full_window", null)
+  notify_no_data         = lookup(each.value, "notify_no_data", null)
+  new_host_delay         = lookup(each.value, "new_host_delay", null)
+  new_group_delay        = lookup(each.value, "new_group_delay", null)
+  groupby_simple_monitor = lookup(each.value, "groupby_simple_monitor", null)
+  evaluation_delay       = lookup(each.value, "evaluation_delay", null)
+  no_data_timeframe      = lookup(each.value, "no_data_timeframe", null)
+  renotify_interval      = lookup(each.value, "renotify_interval", null)
+  renotify_occurrences   = lookup(each.value, "renotify_occurrences", null)
+  renotify_statuses      = lookup(each.value, "renotify_statuses", null)
+  notify_audit           = lookup(each.value, "notify_audit", null)
+  timeout_h              = lookup(each.value, "timeout_h", null)
+  include_tags           = lookup(each.value, "include_tags", null)
+  enable_logs_sample     = lookup(each.value, "enable_logs_sample", null)
+  force_delete           = lookup(each.value, "force_delete", null)
+  validate               = lookup(each.value, "validate", null)
 
   monitor_thresholds {
     warning           = lookup(each.value.thresholds, "warning", null)

--- a/variables.tf
+++ b/variables.tf
@@ -1,28 +1,41 @@
 # https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor
 variable "datadog_monitors" {
-  type = map(object({
-    name                = string
-    type                = string
-    message             = string
-    escalation_message  = string
-    query               = string
-    tags                = list(string)
-    notify_no_data      = bool
-    new_host_delay      = number
-    evaluation_delay    = number
-    no_data_timeframe   = number
-    renotify_interval   = number
-    notify_audit        = bool
-    timeout_h           = number
-    enable_logs_sample  = bool
-    include_tags        = bool
-    require_full_window = bool
-    locked              = bool
-    force_delete        = bool
-    threshold_windows   = map(any)
-    thresholds          = map(any)
-  }))
-  description = "Map of Datadog monitor configurations. See catalog for examples"
+  type        = map(any)
+  description = <<-EOT
+    Map of Datadog monitor configurations. See catalog for examples
+    The objects shall be constructed as follows, since not all data is required, we will use map(any) with
+    lookups and their defaults
+    ```
+    type = map(object({
+      name                   = string
+      type                   = string
+      priority               = number
+      message                = string
+      escalation_message     = string
+      query                  = string
+      tags                   = list(string)
+      notify_no_data         = bool
+      new_host_delay         = number
+      new_group_delay        = number
+      groupby_simple_monitor = bool
+      evaluation_delay       = number
+      no_data_timeframe      = number
+      renotify_interval      = number
+      renotify_occurrences   = number
+      renotify_statuses      = list(string)
+      notify_audit           = bool
+      timeout_h              = number
+      enable_logs_sample     = bool
+      include_tags           = bool
+      require_full_window    = bool
+      locked                 = bool
+      force_delete           = bool
+      threshold_windows      = map(any)
+      thresholds             = map(any)
+      validate               = bool
+    }))
+    ```
+  EOT
 }
 
 variable "alert_tags" {


### PR DESCRIPTION
## what

The main resource for "datadog_monitor" was missing several inputs, even the examples include those inputs but they all set to "null" when applied or plan.
* main.tf to include the missing inputs with lookup function
* datadog_monitors variable was updated to use map(any) with objects in description
* no README reference was found to update
* examples have all these inputs, no need to add


## why

Priority and others are essential part of the monitors to be used in some cases

## references

#85 
