### PR TITLE
fix(synthetics): Add elements operator to Synthetics Tests JSON Path assertion

### DIFF
--- a/modules/synthetics/main.tf
+++ b/modules/synthetics/main.tf
@@ -63,9 +63,10 @@ resource "datadog_synthetics_test" "default" {
             for_each = assertion.value.operator == "validatesJSONPath" ? [lookup(assertion.value, "targetjsonpath", lookup(assertion.value, "target", null))] : []
 
             content {
-              jsonpath    = lookup(targetjsonpath.value, "jsonpath", lookup(targetjsonpath.value, "jsonPath", null))
-              operator    = targetjsonpath.value.operator
-              targetvalue = lookup(targetjsonpath.value, "targetvalue", lookup(targetjsonpath.value, "targetValue", null))
+              jsonpath         = lookup(targetjsonpath.value, "jsonpath", lookup(targetjsonpath.value, "jsonPath", null))
+              elementsoperator = lookup(targetjsonpath.value, "elementsoperator", lookup(targetjsonpath.value, "elementsOperator", null))
+              operator         = targetjsonpath.value.operator
+              targetvalue      = lookup(targetjsonpath.value, "targetvalue", lookup(targetjsonpath.value, "targetValue", null))
             }
           }
 
@@ -199,9 +200,10 @@ resource "datadog_synthetics_test" "default" {
         for_each = assertion.value.operator == "validatesJSONPath" ? [lookup(assertion.value, "targetjsonpath", lookup(assertion.value, "target", null))] : []
 
         content {
-          jsonpath    = lookup(targetjsonpath.value, "jsonpath", lookup(targetjsonpath.value, "jsonPath", null))
-          operator    = targetjsonpath.value.operator
-          targetvalue = lookup(targetjsonpath.value, "targetvalue", lookup(targetjsonpath.value, "targetValue", null))
+          jsonpath         = lookup(targetjsonpath.value, "jsonpath", lookup(targetjsonpath.value, "jsonPath", null))
+          elementsoperator = lookup(targetjsonpath.value, "elementsoperator", lookup(targetjsonpath.value, "elementsOperator", null))
+          operator         = targetjsonpath.value.operator
+          targetvalue      = lookup(targetjsonpath.value, "targetvalue", lookup(targetjsonpath.value, "targetValue", null))
         }
       }
 


### PR DESCRIPTION
## what

- Add missing field `elementsoperator` to Synthetics Tests' JSON Path Assertion. 
- Add missing field to both multi-step and overall Assertions.

## why

- The field `elementsoperator` appears to have been missed in the module.
- When attempting to set `elementsoperator`, it always uses the default value of `firstElementMatches`, so we are unable to set other values, such as `everyElementMatches`.

## references

- https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/synthetics_test#elementsoperator-1
- https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/synthetics_test#elementsoperator-2

