### PR TITLE
feat(synthetics): Add JavaScript Assertions to Synthetics Tests

### DIFF
--- a/modules/synthetics/main.tf
+++ b/modules/synthetics/main.tf
@@ -54,10 +54,11 @@ resource "datadog_synthetics_test" "default" {
         for_each = lookup(api_step.value, "assertion", lookup(api_step.value, "assertions", []))
 
         content {
-          operator = assertion.value.operator
+          operator = lookup(assertion.value, "operator", null)
           type     = assertion.value.type
           property = lookup(assertion.value, "property", null)
           target   = try(tostring(assertion.value.target), null)
+          code     = lookup(assertion.value, "code", null)
 
           dynamic "targetjsonpath" {
             for_each = assertion.value.operator == "validatesJSONPath" ? [lookup(assertion.value, "targetjsonpath", lookup(assertion.value, "target", null))] : []
@@ -191,10 +192,11 @@ resource "datadog_synthetics_test" "default" {
   dynamic "assertion" {
     for_each = lookup(each.value, "assertion", try(each.value.config.assertions, []))
     content {
-      operator = assertion.value.operator
+      operator = lookup(assertion.value, "operator", null)
       type     = assertion.value.type
       property = lookup(assertion.value, "property", null)
       target   = try(tostring(assertion.value.target), null)
+      code     = lookup(assertion.value, "code", null)
 
       dynamic "targetjsonpath" {
         for_each = assertion.value.operator == "validatesJSONPath" ? [lookup(assertion.value, "targetjsonpath", lookup(assertion.value, "target", null))] : []

--- a/modules/synthetics/versions.tf
+++ b/modules/synthetics/versions.tf
@@ -4,8 +4,8 @@ terraform {
   required_providers {
     datadog = {
       source = "datadog/datadog"
-      # Must have >= 3.43.1 to have fix for https://github.com/DataDog/terraform-provider-datadog/issues/2531
-      version = ">= 3.43.1"
+      # Must have >= 3.45.0 to have include JavaScript Assertions
+      version = ">= 3.49.0"
     }
   }
 }


### PR DESCRIPTION
Increase provider version to include JavaScript Assertions for Synthetics Tests. Change 'operator' to an optional field and include 'code' field.

## what

- This will allow JavaScript Assertions to be added to API and Multi-Step API Synthetics Tests. 

## why

- This is new functionality made available in Terraform Datadog Provider v3.45.0 that was previously not available for the module.

## references

- https://registry.terraform.io/providers/DataDog/datadog/3.45.0/docs/resources/synthetics_test#nested-schema-for-assertion
- https://registry.terraform.io/providers/DataDog/datadog/3.45.0/docs/resources/synthetics_test#nested-schema-for-api_stepassertion