### PR TITLE
feat!: removes locked argument from datadog_monitor resources; bumps datadog provider minimum version to 4.0.0

### DIFF
--- a/catalog/monitors/amq.yaml
+++ b/catalog/monitors/amq.yaml
@@ -23,7 +23,6 @@ amq-cpu-utilization:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -65,7 +64,6 @@ amq-heap-usage:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -104,7 +102,6 @@ amq-network-in:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 900
@@ -145,7 +142,6 @@ amq-network-out:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 900
@@ -186,7 +182,6 @@ amq-current-connections-count:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 900

--- a/catalog/monitors/aurora.yaml
+++ b/catalog/monitors/aurora.yaml
@@ -23,7 +23,6 @@ aurora-replica-lag:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60

--- a/catalog/monitors/ec2.yaml
+++ b/catalog/monitors/ec2.yaml
@@ -18,7 +18,6 @@ ec2-failed-status-check:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60

--- a/catalog/monitors/host.yaml
+++ b/catalog/monitors/host.yaml
@@ -17,7 +17,6 @@ host-io-wait-times:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -53,7 +52,6 @@ host-disk-use:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -89,7 +87,6 @@ host-high-mem-use:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -125,7 +122,6 @@ host-high-load-avg:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60

--- a/catalog/monitors/k8s.yaml
+++ b/catalog/monitors/k8s.yaml
@@ -18,7 +18,6 @@ k8s-deployment-replica-pod-down:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
@@ -50,7 +49,6 @@ k8s-pod-restarting:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
@@ -83,7 +81,6 @@ k8s-statefulset-replica-down:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
@@ -116,7 +113,6 @@ k8s-daemonset-pod-down:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
@@ -148,7 +144,6 @@ k8s-crashloopBackOff:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
@@ -180,7 +175,6 @@ k8s-multiple-pods-failing:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
@@ -213,7 +207,6 @@ k8s-unavailable-deployment-replica:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -250,7 +243,6 @@ k8s-unavailable-statefulset-replica:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -287,7 +279,6 @@ k8s-node-status-unschedulable:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -324,7 +315,6 @@ k8s-imagepullbackoff:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -361,7 +351,6 @@ k8s-high-cpu-usage:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -398,7 +387,6 @@ k8s-high-disk-usage:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -440,7 +428,6 @@ k8s-high-memory-usage:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -482,7 +469,6 @@ k8s-high-filesystem-usage:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -524,7 +510,6 @@ k8s-network-tx-errors:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -566,7 +551,6 @@ k8s-network-rx-errors:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -603,7 +587,6 @@ k8s-node-not-ready:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -640,7 +623,6 @@ k8s-kube-api-down:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -677,7 +659,6 @@ k8s-increased-pod-crash:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -717,7 +698,6 @@ k8s-hpa-errors:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -755,7 +735,6 @@ k8s-pending-pods:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60

--- a/catalog/monitors/rabbitmq.yaml
+++ b/catalog/monitors/rabbitmq.yaml
@@ -19,7 +19,6 @@ rabbitmq-messages-unacknowledged-rate-too-high:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60
@@ -58,7 +57,6 @@ rabbitmq-disk-usage-too-high:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 0
   timeout_h: 0
   evaluation_delay: 60

--- a/catalog/monitors/rds.yaml
+++ b/catalog/monitors/rds.yaml
@@ -23,7 +23,6 @@ rds-cpuutilization:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -65,7 +64,6 @@ rds-disk-queue-depth:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -107,7 +105,6 @@ rds-freeable-memory:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -149,7 +146,6 @@ rds-swap-usage:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -191,7 +187,6 @@ rds-database-connections:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60

--- a/catalog/monitors/redshift.yaml
+++ b/catalog/monitors/redshift.yaml
@@ -20,7 +20,6 @@ redshift-health-status:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -59,7 +58,6 @@ redshift-database-connections:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -103,7 +101,6 @@ redshift-cpuutilization:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -145,7 +142,6 @@ redshift-write-latency:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -187,7 +183,6 @@ redshift-disk-space-used:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -226,7 +221,6 @@ redshift-network-receive:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -267,7 +261,6 @@ redshift-network-transmit:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -308,7 +301,6 @@ redshift-read-throughput:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60
@@ -349,7 +341,6 @@ redshift-write-throughput:
   enable_logs_sample: false
   force_delete: true
   include_tags: true
-  locked: false
   renotify_interval: 60
   timeout_h: 0
   evaluation_delay: 60

--- a/examples/child_organization/versions.tf
+++ b/examples/child_organization/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 3.0.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 3.0.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/examples/organization_settings/versions.tf
+++ b/examples/organization_settings/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 3.0.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/examples/rbac/versions.tf
+++ b/examples/rbac/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 3.0.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/examples/slo/catalog/monitor_slo.yaml
+++ b/examples/slo/catalog/monitor_slo.yaml
@@ -36,7 +36,6 @@ monitor-slo:
       enable_logs_sample: false
       force_delete: true
       include_tags: true
-      locked: false
       renotify_interval: 60
       timeout_h: 0
       evaluation_delay: 60

--- a/examples/slo/versions.tf
+++ b/examples/slo/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 3.0.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/examples/synthetics/versions.tf
+++ b/examples/synthetics/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = ">=3.43.1"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -42,9 +42,5 @@ resource "datadog_monitor" "default" {
   # Only these roles will have access to the monitor according to their permissions
   restricted_roles = try(var.restricted_roles_map[each.key], null)
 
-  # `restricted_roles` conflicts with `locked`
-  # Use `locked`` only if `restricted_roles` is not provided
-  locked = try(var.restricted_roles_map[each.key], null) == null ? lookup(each.value, "locked", null) : null
-
   tags = lookup(each.value, "tags", module.this.tags)
 }

--- a/modules/child_organization/versions.tf
+++ b/modules/child_organization/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 3.0.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/modules/monitors/main.tf
+++ b/modules/monitors/main.tf
@@ -19,10 +19,6 @@ resource "datadog_monitor" "default" {
   # If `restricted_roles` is present var map, it takes precedence over the setting in the monitor definition.
   restricted_roles = try(var.restricted_roles_map[each.key], try(each.value.restricted_roles, null))
 
-  # `restricted_roles` conflicts with `locked`, which is deprecated.
-  # Use `locked`` only if present and `restricted_roles` is not provided.
-  locked = try(var.restricted_roles_map[each.key], try(each.value.restricted_roles, null)) == null ? try(each.value.options.locked, null) : null
-
   # Allow publishing Monitors as drafts for evaluation
   draft_status = try(each.value.draft_status, null)
 

--- a/modules/monitors/normalize-legacy.tf
+++ b/modules/monitors/normalize-legacy.tf
@@ -19,7 +19,6 @@ locals {
     "evaluation_delay",
     "groupby_simple_monitor",
     "include_tags",
-    "locked",
     "new_group_delay",
     "new_host_delay",
     "no_data_timeframe",

--- a/modules/monitors/versions.tf
+++ b/modules/monitors/versions.tf
@@ -4,9 +4,8 @@ terraform {
   required_providers {
     datadog = {
       source = "datadog/datadog"
-      # >= 3.36.0 is required, so that bugfix for "start" is included.
-      # See https://github.com/DataDog/terraform-provider-datadog/issues/2255
-      version = ">= 3.36.0"
+
+      version = ">= 4.0.0"
     }
   }
 }

--- a/modules/organization_settings/versions.tf
+++ b/modules/organization_settings/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 3.0.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/modules/permissions/versions.tf
+++ b/modules/permissions/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 3.0.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/modules/roles/versions.tf
+++ b/modules/roles/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 3.0.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/modules/slo/README.md
+++ b/modules/slo/README.md
@@ -81,7 +81,6 @@ monitor-slo:
       enable_logs_sample: false
       force_delete: true
       include_tags: true
-      locked: false
       renotify_interval: 60
       timeout_h: 0
       evaluation_delay: 60

--- a/modules/slo/versions.tf
+++ b/modules/slo/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 3.0.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/modules/synthetics/versions.tf
+++ b/modules/synthetics/versions.tf
@@ -3,9 +3,8 @@ terraform {
 
   required_providers {
     datadog = {
-      source = "datadog/datadog"
-      # Must have >= 3.43.1 to have fix for https://github.com/DataDog/terraform-provider-datadog/issues/2531
-      version = ">= 3.43.1"
+      source  = "datadog/datadog"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,6 @@ variable "datadog_monitors" {
     enable_logs_sample  = bool
     include_tags        = bool
     require_full_window = bool
-    locked              = bool
     force_delete        = bool
     threshold_windows   = map(any)
     thresholds          = map(any)

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 3.0.0"
+      version = ">= 4.0.0"
     }
   }
 }


### PR DESCRIPTION
## what

- **BREAKING**  bumps datadog provider minimum version to 4.0.0
- **BREAKING** removes locked argument from datadog_monitor resources

## why

- DataDog major version release (v4+) removes deprecated `locked` argument from `datadog_monitor` resource

## references

- https://registry.terraform.io/providers/DataDog/datadog/latest/docs/guides/v4-upgrade-guide#removed-locked-on-datadog_monitor
